### PR TITLE
Bump action runtime from node20 to node24

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -23,5 +23,5 @@ inputs:
     description: 'The ACL permissions to set for the file.'
     default: public-read
 runs:
-  using: node20
+  using: node24
   main: dist/index.js


### PR DESCRIPTION
## Description

Bumps `action.yml` runtime declaration from `node20` to `node24`. GitHub is deprecating Node.js 20 actions: runners will be forced to Node 24 by default starting 2026-06-02, and Node 20 will be removed from runners on 2026-09-16. Consumer workflows (e.g. scribd/scribd-android) have started emitting deprecation warnings for this action.

The bundled `dist/index.js` is pre-compiled JS via `ncc` and runs as-is on Node 24, so no rebuild is required.

## Testing considerations

No tests exist in this repo. Verification will happen via a consumer workflow run after the `v2` tag is moved to this commit.

## Checklist

- [ ] Prefixed the PR title with the JIRA ticket code
- [x] Performed simple, atomic commits with good commit messages
- [x] Verified that the commit history is linear and commits are squashed as necessary
- [ ] Thoroughly tested the changes
- [ ] The appropriate complexity label (Low, Medium, High) is added to this PR
- [ ] Test Coverage of changes (if applicable)
- [ ] Updated the `README.md` as necessary
- [ ] I have confirmed and checked all of these boxes

## Related links

* GitHub Node 20 deprecation notice: https://github.blog/changelog/

## Follow-up

After merge, move the floating `v2` tag to the new commit and cut a `v2.0.6` release so consumers pinned at `@v2` pick up the change automatically.
